### PR TITLE
Space preserve scripts

### DIFF
--- a/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
+++ b/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
@@ -112,7 +112,6 @@ public class DocxTemplater {
     private static String NEW_LINE_PLACEHOLDER = "26f679ad-e7fd-4d42-9e05-946f393c277d";
     private static String WT_NO_PRESERVE = "<w:t>";
     private static String WT_SPACE_PRESERVE = "<w:t xml:space=\"preserve\">";
-    private static String SPACE_PRESERVE = "xml:space=\"preserve\"";
 
     protected static Map<String, Object> processParams(Map<String, Object> params) {
         Map<String, Object> res = new HashMap<String, Object>();
@@ -170,8 +169,8 @@ public class DocxTemplater {
         int i = 0;
         for (String piece : pieces) {
             Placeholder nextScript = i < scripts.size() ? scripts.get(i) : null;
-            if (piece.endsWith(WT_NO_PRESERVE) && nextScript != null && nextScript.text.contains(SPACE_PRESERVE)) {
-                // Preserve spaces if one of the elements inside the following script block preserves them
+            if (nextScript != null && piece.endsWith(WT_NO_PRESERVE)) {
+                // Always preserve spaces of scripts and between scripts
                 piece = piece.substring(0, piece.length() - WT_NO_PRESERVE.length()) + WT_SPACE_PRESERVE;
             }
 

--- a/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
+++ b/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
@@ -36,6 +36,7 @@ public class DocxTemplater {
     private InputStream templateStream;
     private String streamTemplateKey;
     private TemplateEngine templateEngine;
+    private boolean spacePreserve;
 
     /**
      * Set default Template Engine
@@ -168,7 +169,7 @@ public class DocxTemplater {
 
         int i = 0;
         for (String piece : pieces) {
-            if (i < scripts.size() && piece.endsWith(WT_NO_PRESERVE)) {
+            if (spacePreserve && i < scripts.size() && piece.endsWith(WT_NO_PRESERVE)) {
                 // Always preserve spaces of the following scripts
                 piece = piece.substring(0, piece.length() - WT_NO_PRESERVE.length()) + WT_SPACE_PRESERVE;
             }
@@ -403,6 +404,16 @@ public class DocxTemplater {
      */
     public void setTemplateEngine(TemplateEngine templateEngine) {
         this.templateEngine = templateEngine;
+    }
+
+    /**
+     * When spaces around scripts should be preserved.
+     * Defaults to <code>false</code>
+     *
+     * @param spacePreserve Preserve spaces around scripts?
+     */
+    public void setSpacePreserve(boolean spacePreserve) {
+        this.spacePreserve = spacePreserve;
     }
 
 }

--- a/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
+++ b/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
@@ -168,16 +168,15 @@ public class DocxTemplater {
 
         int i = 0;
         for (String piece : pieces) {
-            Placeholder nextScript = i < scripts.size() ? scripts.get(i) : null;
-            if (nextScript != null && piece.endsWith(WT_NO_PRESERVE)) {
-                // Always preserve spaces of scripts and between scripts
+            if (i < scripts.size() && piece.endsWith(WT_NO_PRESERVE)) {
+                // Always preserve spaces of the following scripts
                 piece = piece.substring(0, piece.length() - WT_NO_PRESERVE.length()) + WT_SPACE_PRESERVE;
             }
 
             tplSkeleton.add(new Placeholder(UUID.randomUUID().toString(), piece, PlaceholderType.TEXT));
 
-            if (nextScript != null) {
-                tplSkeleton.add(nextScript);
+            if (i < scripts.size()) {
+                tplSkeleton.add(scripts.get(i));
             }
             i++;
         }

--- a/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
+++ b/src/main/java/org/scriptlet4docx/docx/DocxTemplater.java
@@ -110,6 +110,9 @@ public class DocxTemplater {
     }
 
     private static String NEW_LINE_PLACEHOLDER = "26f679ad-e7fd-4d42-9e05-946f393c277d";
+    private static String WT_NO_PRESERVE = "<w:t>";
+    private static String WT_SPACE_PRESERVE = "<w:t xml:space=\"preserve\">";
+    private static String SPACE_PRESERVE = "xml:space=\"preserve\"";
 
     protected static Map<String, Object> processParams(Map<String, Object> params) {
         Map<String, Object> res = new HashMap<String, Object>();
@@ -166,10 +169,16 @@ public class DocxTemplater {
 
         int i = 0;
         for (String piece : pieces) {
+            Placeholder nextScript = i < scripts.size() ? scripts.get(i) : null;
+            if (piece.endsWith(WT_NO_PRESERVE) && nextScript != null && nextScript.text.contains(SPACE_PRESERVE)) {
+                // Preserve spaces if one of the elements inside the following script block preserves them
+                piece = piece.substring(0, piece.length() - WT_NO_PRESERVE.length()) + WT_SPACE_PRESERVE;
+            }
+
             tplSkeleton.add(new Placeholder(UUID.randomUUID().toString(), piece, PlaceholderType.TEXT));
 
-            if (i < scripts.size()) {
-                tplSkeleton.add(scripts.get(i));
+            if (nextScript != null) {
+                tplSkeleton.add(nextScript);
             }
             i++;
         }

--- a/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
+++ b/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
@@ -642,7 +642,7 @@ public class DocxTemplaterTest extends Assert {
         String result = templater.processCleanedTemplate(template, params);
 
         assertTrue(result != null);
-        assertTrue(result.contains("<w:t xml:space=\"preserve\">First </w:t>"));
-        assertTrue(result.contains("<w:t xml:space=\"preserve\">Second</w:t>"));
+        assertTrue(result.contains("<w:t xml:space=\"preserve\">one two </w:t>"));
+        assertTrue(result.contains("<w:t xml:space=\"preserve\">three</w:t>"));
     }
 }

--- a/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
+++ b/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
@@ -635,7 +635,7 @@ public class DocxTemplaterTest extends Assert {
     }
 
     @Test
-    public void testProcessScriptedTemplate_spacePreserveAfterScript() throws Exception {
+    public void testProcessScriptedTemplate_spacePreserveScript() throws Exception {
         String template = TestUtils.readResource("/docx/DocxTemplaterTest-21.xml");
         DocxTemplater templater = new DocxTemplater(none);
         template = templater.cleanupTemplate(template);

--- a/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
+++ b/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
@@ -638,11 +638,24 @@ public class DocxTemplaterTest extends Assert {
     public void testProcessScriptedTemplate_spacePreserveScript() throws Exception {
         String template = TestUtils.readResource("/docx/DocxTemplaterTest-21.xml");
         DocxTemplater templater = new DocxTemplater(none);
+        templater.setSpacePreserve(true);
         template = templater.cleanupTemplate(template);
         String result = templater.processCleanedTemplate(template, params);
 
         assertTrue(result != null);
         assertTrue(result.contains("<w:t xml:space=\"preserve\">one two </w:t>"));
         assertTrue(result.contains("<w:t xml:space=\"preserve\">three</w:t>"));
+    }
+
+    @Test
+    public void testProcessScriptedTemplate_noSpacePreserveScript() throws Exception {
+        String template = TestUtils.readResource("/docx/DocxTemplaterTest-21.xml");
+        DocxTemplater templater = new DocxTemplater(none);
+        template = templater.cleanupTemplate(template);
+        String result = templater.processCleanedTemplate(template, params);
+
+        assertTrue(result != null);
+        assertTrue(result.contains("<w:t>one two </w:t>"));
+        assertTrue(result.contains("<w:t>three</w:t>"));
     }
 }

--- a/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
+++ b/src/test/java/org/scriptlet4docx/docx/DocxTemplaterTest.java
@@ -633,4 +633,16 @@ public class DocxTemplaterTest extends Assert {
         assertTrue(result.contains("this is A<w:br/>"));
         assertTrue(StringUtils.countMatches(result, "this is A<w:br/>") == 4);
     }
+
+    @Test
+    public void testProcessScriptedTemplate_spacePreserveAfterScript() throws Exception {
+        String template = TestUtils.readResource("/docx/DocxTemplaterTest-21.xml");
+        DocxTemplater templater = new DocxTemplater(none);
+        template = templater.cleanupTemplate(template);
+        String result = templater.processCleanedTemplate(template, params);
+
+        assertTrue(result != null);
+        assertTrue(result.contains("<w:t xml:space=\"preserve\">First </w:t>"));
+        assertTrue(result.contains("<w:t xml:space=\"preserve\">Second</w:t>"));
+    }
 }

--- a/src/test/resources/docx/DocxTemplaterTest-21.xml
+++ b/src/test/resources/docx/DocxTemplaterTest-21.xml
@@ -18,7 +18,21 @@
 				<w:rPr>
 					<w:lang w:val="en-US"/>
 				</w:rPr>
-				<w:t>First</w:t>
+				<w:t>one</w:t>
+			</w:r>
+			<w:proofErr w:type="gramEnd"/>
+			<w:r w:rsidR="00507F5D" w:rsidRPr="00084DB5">
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>'); %&gt; &lt;%out.print('</w:t>
+			</w:r>
+			<w:proofErr w:type="gramStart"/>
+			<w:r w:rsidR="00507F5D" w:rsidRPr="00084DB5">
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>two</w:t>
 			</w:r>
 			<w:proofErr w:type="gramEnd"/>
 			<w:r w:rsidR="00507F5D" w:rsidRPr="00084DB5">
@@ -45,13 +59,13 @@
 				<w:rPr>
 					<w:lang w:val="en-US"/>
 				</w:rPr>
-				<w:t>Second</w:t>
+				<w:t>three</w:t>
 			</w:r>
 			<w:r w:rsidR="009D34AF" w:rsidRPr="00084DB5">
 				<w:rPr>
 					<w:lang w:val="en-US"/>
 				</w:rPr>
-				<w:t xml:space="preserve">'); %&gt;</w:t>
+				<w:t>'); %&gt;</w:t>
 			</w:r>
 		</w:p>
 		<w:sectPr w:rsidR="00851669" w:rsidRPr="00164122">

--- a/src/test/resources/docx/DocxTemplaterTest-21.xml
+++ b/src/test/resources/docx/DocxTemplaterTest-21.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 wp14">
+	<w:body>
+		<w:p w:rsidR="00851669" w:rsidRPr="00164122" w:rsidRDefault="00851669">
+			<w:pPr>
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+			</w:pPr>
+			<w:r>
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>&lt;%out.print('</w:t>
+			</w:r>
+			<w:proofErr w:type="gramStart"/>
+			<w:r w:rsidR="00507F5D" w:rsidRPr="00084DB5">
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>First</w:t>
+			</w:r>
+			<w:proofErr w:type="gramEnd"/>
+			<w:r w:rsidR="00507F5D" w:rsidRPr="00084DB5">
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t xml:space="preserve">'); %&gt; </w:t>
+			</w:r>
+			<w:r>
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>&lt;%out.print</w:t>
+			</w:r>
+			<w:proofErr w:type="spellStart"/>
+			<w:r>
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>('</w:t>
+			</w:r>
+			<w:proofErr w:type="spellEnd"/>
+			<w:r w:rsidR="008D04F8" w:rsidRPr="00084DB5">
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t>Second</w:t>
+			</w:r>
+			<w:r w:rsidR="009D34AF" w:rsidRPr="00084DB5">
+				<w:rPr>
+					<w:lang w:val="en-US"/>
+				</w:rPr>
+				<w:t xml:space="preserve">'); %&gt;</w:t>
+			</w:r>
+		</w:p>
+		<w:sectPr w:rsidR="00851669" w:rsidRPr="00164122">
+			<w:pgSz w:w="11906" w:h="16838"/>
+			<w:pgMar w:top="1134" w:right="850" w:bottom="1134" w:left="1701" w:header="708" w:footer="708" w:gutter="0"/>
+			<w:cols w:space="708"/>
+			<w:docGrid w:linePitch="360"/>
+		</w:sectPr>
+	</w:body>
+</w:document>


### PR DESCRIPTION
This PR fixes lost whitespaces in and between scripts.

A space is lost if the replacement results in an element with leading or trailing spaces:
`<w:t>one two </w:t>`
instead of
`<w:t xml:space="preserve">one two </w:t>`

Edit: Made the behavior an opt-in because it can be a breaking change for some templates.